### PR TITLE
Fix errors causing skill load failure

### DIFF
--- a/neon_skill_audio_recording/__init__.py
+++ b/neon_skill_audio_recording/__init__.py
@@ -38,6 +38,7 @@ from ovos_workshop.skills import OVOSSkill
 
 class AudioRecordingSkill(OVOSSkill):
     def __init__(self, **kwargs):
+        OVOSSkill.__init__(self, **kwargs)
         self.recording = False
         self.add_event("recognizer_loop:record_stop", self.handle_recording_stop)
 

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,6 @@ setup(
     author_email='developers@neon.ai',
     license='BSD-3-Clause',
     install_requires=get_requirements("requirements.txt"),
-    package_dir={SKILL_PKG: ""},
     package_data={SKILL_PKG: find_resource_files()},
     packages=[SKILL_PKG],
     include_package_data=True,


### PR DESCRIPTION
# Description
Adds call to `OVOSSkill.__init__`
Removes invalid `package_dir` spec in `setup.py`

# Issues
Fixes bug missed in #9 
Fixes bug missed in #10 

# Other Notes
Verified skill load on Mark 2